### PR TITLE
Rate limit submit report for unauthorized users

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,11 +2,12 @@
 
 namespace App\Providers;
 
-use Illuminate\Cache\RateLimiting\Limit;
-use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -59,6 +60,22 @@ class RouteServiceProvider extends ServiceProvider
     {
         RateLimiter::for('api', function (Request $request) {
             return Limit::perMinute(60)->by(optional($request->user())->id ?: $request->ip());
+        });
+
+        RateLimiter::for('report.store', function (Request $request)
+        {
+            if ($request->user()->hasPermission('manage station')) {
+                return Limit::none();
+            }
+
+            if ($request->user()->hasPermission('operate station')) {
+                return Limit::none();
+            }
+
+            return Limit::perMinutes(3, 5)->by($request->user()->id)->response(function () use ($request)
+            {
+                return response("Maximum attempts reached. Please try again in few minutes", 429);
+            });
         });
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -84,6 +84,6 @@ Route::middleware('auth')->prefix('station/{station}/report')->name('station.rep
 {
     Route::get('/', [StationReportController::class, 'index'])->name('index');
     Route::get('/{report}', [StationReportController::class, 'show'])->name('show');
-    Route::post('/', [StationReportController::class, 'store'])->name('store');
+    Route::post('/', [StationReportController::class, 'store'])->middleware('throttle:report.store')->name('store');
     Route::put('/resolve', [StationReportController::class, 'resolve'])->name('resolve');
 });


### PR DESCRIPTION
- Rate limit store report for user that has no permissions `$user->permissions = null` (maximum 5 reports for 3 minutes)